### PR TITLE
fix(desmos): set namespace in default secret

### DIFF
--- a/charts/desmos/templates/secret.yaml
+++ b/charts/desmos/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "desmos.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "desmos.labels" . | nindent 4 }}
 type: Opaque


### PR DESCRIPTION
Fix an issue in the Desmos project related to setting the namespace in the default secret configuration.